### PR TITLE
:zap: Add: game window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# コンパイラとフラグの設定
+CC = gcc
+CFLAGS = -Wall -g
+
+# ソースファイルがあるディレクトリ
+SRCDIR = src
+
+# ソースファイルのリスト
+SRCS = $(wildcard $(SRCDIR)/*.c)
+
+# オブジェクトファイルのリスト
+OBJS = $(SRCS:$(SRCDIR)/%.c=%.o)
+
+# 出力実行ファイル
+EXEC = wordle
+
+# デフォルトターゲット（make実行時に呼ばれる）
+all: $(EXEC)
+
+# 実行ファイルの作成
+$(EXEC): $(OBJS)
+	$(CC) $(OBJS) -o $(EXEC) -lncurses
+
+# オブジェクトファイルの作成
+%.o: $(SRCDIR)/%.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+# クリーンターゲット（ビルドファイルを削除）
+clean:
+	rm -f $(OBJS) $(EXEC)
+
+# インストールターゲット（任意で作成）
+install:
+	@echo "Installing $(EXEC)..."
+	@# 実行ファイルを適切な場所にコピーする処理を記述することができます。
+
+# テストターゲット（任意で作成）
+test:
+	@echo "Running tests..."
+	@# 必要に応じてテストスクリプトを呼び出すことができます。
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,77 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1737632463,
+        "narHash": "sha256-38J9QfeGSej341ouwzqf77WIHAScihAKCt8PQJ+NH28=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "0aa475546ed21629c4f5bbf90e38c846a99ec9e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,47 @@
+#include <ncurses.h>
+#include <stdio.h>
+
+int rulare(int joc) {
+    while (joc == 1) {
+        clear();
+        initscr();
+        start_color();
+        init_pair(1, COLOR_BLACK, COLOR_GREEN);
+
+        // ゲームボード描画
+        int x, y;
+        getmaxyx(stdscr, x, y);
+        move(0, y / 2);
+        printw("Wordle Game (Developing!)\n");
+        refresh();
+
+        // ゲームボード作成
+        int h = 5, w = 10, sty = 5, stx = x / 2, i, j;
+        int pozx[6][6], pozy[6][6];
+
+        for (i = 0; i < 6; i++) {
+            for (j = 0; j < 5; j++) {
+                WINDOW* win = newwin(h, w, sty, stx);
+                refresh();
+                box(win, 0, 0);
+                wrefresh(win);
+                pozx[i][j] = sty + h / 2;
+                pozy[i][j] = stx + w / 2;
+                stx = stx + 10;
+            }
+            stx = x / 2;
+            sty = sty + 5;
+        }
+
+        joc = 0;
+    }
+    return 0;
+}
+
+int main() {
+    int joc = 1;
+    clear();
+    rulare(joc);
+    return 0;
+}
+


### PR DESCRIPTION
This pull request introduces a new `Makefile` to automate the build process and adds initial implementation for a Wordle game in the `src/main.c` file. The changes are primarily focused on setting up the build environment and creating the game board using the `ncurses` library.

### Build System Setup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R41): Added a new `Makefile` to define the compiler, flags, source files, object files, and targets for building, cleaning, installing, and testing the project.

### Game Implementation:

* [`src/main.c`](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R1-R47): Added initial implementation of the Wordle game, including setting up the game board with `ncurses` and a basic game loop structure.